### PR TITLE
fix-fly-deprecated-app-creation-command-edu-102

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ fi
 
 # Deploy the Fly app, creating it first if needed.
 if ! flyctl status --app "$app"; then
-  flyctl create --name "$app" --org "$org"
+  flyctl apps create --name "$app" --org "$org"
 fi
 
 # Attach postgres cluster to the app if specified.


### PR DESCRIPTION
## Description

This PR removes the deprecated `flyctl create` command in favor of `flyctl app create`. 

## Related Issue

[EDU-102/fix-fly-deprecated-app-creation-command](https://linear.app/fewlines/issue/EDU-102/fix-fly-deprecated-app-creation-command)

## Motivation and Context

Make fly work again.

## Types of changes

- Chore (non-breaking change which refactors / improves the existing code base)
- Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to
  change)~

